### PR TITLE
Fix misformatted paragraph in "Dagster: the Data Orchestrator" post

### DIFF
--- a/pages/blog/dagster-the-data-orchestrator.mdx
+++ b/pages/blog/dagster-the-data-orchestrator.mdx
@@ -108,7 +108,7 @@ Note that this job is written using the native PySpark API and defines only busi
 
 > ## Dagster provides enough structure so that these infrastructure concerns can be abstracted away from business logic using resources and then shared across the broader ecosystem.
 
-Proper use of these abstractions means code that’s easier to test, more likely to be reused, more observable, and more straightforward to execute in different environments. Our users commonly build libraries of reusable solids and resources, accelerating development in their data platform. We are also starting to feel an ecosystem-wide reuse effect, which is exciting. S*olid*s\* *become reusable components of data processing, and *resources \*become reusable components encapsulating infrastructure concerns.
+Proper use of these abstractions means code that’s easier to test, more likely to be reused, more observable, and more straightforward to execute in different environments. Our users commonly build libraries of reusable solids and resources, accelerating development in their data platform. We are also starting to feel an ecosystem-wide reuse effect, which is exciting. _Solids_ become reusable components of data processing, and _resources_ become reusable components encapsulating infrastructure concerns.
 
 ## Embrace Heterogeneity
 


### PR DESCRIPTION
It appears that this was misformatted when moved from Medium to our own blog.

Before:
![Screen Shot 2021-04-30 at 9 57 06 AM](https://user-images.githubusercontent.com/28738937/116721954-1e66a300-a99b-11eb-8027-efa0f82742b4.png)

After:
![Screen Shot 2021-04-30 at 9 57 22 AM](https://user-images.githubusercontent.com/28738937/116722016-29b9ce80-a99b-11eb-85d7-d8f6fdab626a.png)
