### PR TITLE
Use large summary for Twitter previews

### DIFF
--- a/components/layouts/BlogPost.tsx
+++ b/components/layouts/BlogPost.tsx
@@ -25,7 +25,7 @@ export default function BlogPostLayout({
             <meta name="description" content={frontMatter.excerpt} />
             <meta key="title" name="title" content={title} />
             {/* Twitter */}
-            <meta name="twitter:card" content="summary" />
+            <meta name="twitter:card" content="summary_large_image" />
             <meta name="twitter:title" content={title} />
             <meta
               key="twitter:description"

--- a/components/layouts/Layout.tsx
+++ b/components/layouts/Layout.tsx
@@ -22,7 +22,7 @@ const Layout = ({ children, title = 'Dagster', description = DEFAULT_SHARE_DESCR
       <meta key="title" name="title" content={title} />
       <meta name="description" content={description} />
 
-      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
       <meta
         key="twitter:description"


### PR DESCRIPTION
More click space when our website is shared is always good. Also fixes the issue that our default preview image is cutoff when shared as a square image.